### PR TITLE
Let processHtml() process macros like it does in Portal lib #71

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
 }
 
 dependencies {
+    compileOnly "com.enonic.xp:portal-api:${xpVersion}"
     compileOnly "com.enonic.xp:script-api:${xpVersion}"
 
     compile "com.enonic.xp:lib-auth:${xpVersion}"
@@ -40,7 +41,7 @@ dependencies {
 repositories {
     mavenLocal()
     jcenter()
-    xp.enonicRepo('dev')
+    xp.enonicRepo( 'dev' )
 }
 
 jacocoTestReport {

--- a/src/main/java/com/enonic/lib/guillotine/ProcessHtmlHandler.java
+++ b/src/main/java/com/enonic/lib/guillotine/ProcessHtmlHandler.java
@@ -1,0 +1,66 @@
+package com.enonic.lib.guillotine;
+
+import java.util.function.Supplier;
+
+import com.enonic.lib.guillotine.macro.HtmlAreaProcessedResult;
+import com.enonic.lib.guillotine.macro.ProcessHtmlParams;
+import com.enonic.lib.guillotine.macro.ProcessHtmlService;
+import com.enonic.lib.guillotine.macro.ProcessHtmlServiceImpl;
+import com.enonic.lib.guillotine.mapper.HtmlAreaResultMapper;
+import com.enonic.xp.content.ContentService;
+import com.enonic.xp.macro.MacroService;
+import com.enonic.xp.portal.PortalRequest;
+import com.enonic.xp.portal.url.PortalUrlService;
+import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.script.bean.BeanContext;
+import com.enonic.xp.script.bean.ScriptBean;
+import com.enonic.xp.style.StyleDescriptorService;
+
+public class ProcessHtmlHandler
+    implements ScriptBean
+{
+    private Supplier<ContentService> contentServiceSupplier;
+
+    private Supplier<StyleDescriptorService> styleDescriptorServiceSupplier;
+
+    private Supplier<PortalUrlService> portalUrlServiceSupplier;
+
+    private Supplier<MacroService> macroServiceSupplier;
+
+    private PortalRequest request;
+
+    @Override
+    public void initialize( final BeanContext context )
+    {
+        this.request = context.getBinding( PortalRequest.class ).get();
+
+        this.contentServiceSupplier = context.getService( ContentService.class );
+        this.styleDescriptorServiceSupplier = context.getService( StyleDescriptorService.class );
+        this.portalUrlServiceSupplier = context.getService( PortalUrlService.class );
+        this.macroServiceSupplier = context.getService( MacroService.class );
+    }
+
+    public Object processHtml( ScriptValue params )
+    {
+        final ProcessHtmlParams htmlParams = new ProcessHtmlParams().setPortalRequest( this.request );
+
+        if ( params.getMap().containsKey( "value" ) )
+        {
+            htmlParams.setValue( params.getMap().get( "value" ).toString() );
+        }
+
+        if ( params.getMap().containsKey( "type" ) )
+        {
+            htmlParams.setType( params.getMap().get( "type" ).toString() );
+        }
+
+        final ProcessHtmlService processHtmlService =
+            new ProcessHtmlServiceImpl( contentServiceSupplier.get(), styleDescriptorServiceSupplier.get(), portalUrlServiceSupplier.get(),
+                                        macroServiceSupplier.get() );
+
+        final HtmlAreaProcessedResult result = processHtmlService.processHtml( htmlParams );
+
+        return new HtmlAreaResultMapper( result );
+    }
+
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/HtmlAreaProcessedResult.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/HtmlAreaProcessedResult.java
@@ -1,0 +1,31 @@
+package com.enonic.lib.guillotine.macro;
+
+import java.util.Map;
+
+public class HtmlAreaProcessedResult
+{
+    private final String processedHtml;
+
+    private final Map<String, HtmlMacroResult> macrosAsMap;
+
+    public HtmlAreaProcessedResult( final String processedHtml, final Map<String, HtmlMacroResult> macroMap )
+    {
+        this.processedHtml = processedHtml;
+        this.macrosAsMap = macroMap;
+    }
+
+    public String getProcessedHtml()
+    {
+        return processedHtml;
+    }
+
+    public Map<String, HtmlMacroResult> getMacrosAsMap()
+    {
+        return macrosAsMap;
+    }
+
+    public static HtmlAreaProcessedResult empty()
+    {
+        return new HtmlAreaProcessedResult( "", null );
+    }
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/HtmlLinkProcessor.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/HtmlLinkProcessor.java
@@ -1,0 +1,297 @@
+package com.enonic.lib.guillotine.macro;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.app.ApplicationKeys;
+import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.content.ContentNotFoundException;
+import com.enonic.xp.content.ContentService;
+import com.enonic.xp.content.ExtraData;
+import com.enonic.xp.content.Media;
+import com.enonic.xp.data.Property;
+import com.enonic.xp.media.MediaInfo;
+import com.enonic.xp.portal.PortalRequest;
+import com.enonic.xp.portal.url.AttachmentUrlParams;
+import com.enonic.xp.portal.url.ImageUrlParams;
+import com.enonic.xp.portal.url.PageUrlParams;
+import com.enonic.xp.portal.url.PortalUrlService;
+import com.enonic.xp.site.Site;
+import com.enonic.xp.style.ImageStyle;
+import com.enonic.xp.style.StyleDescriptorService;
+import com.enonic.xp.style.StyleDescriptors;
+
+public class HtmlLinkProcessor
+{
+    private static final ApplicationKey SYSTEM_APPLICATION_KEY = ApplicationKey.from( "com.enonic.xp.app.system" );
+
+    /*
+     * Pattern Constants
+     */
+
+    private static final int MATCH_INDEX = 1;
+
+    private static final int LINK_INDEX = MATCH_INDEX + 1;
+
+    private static final int TYPE_INDEX = LINK_INDEX + 1;
+
+    private static final int MODE_INDEX = TYPE_INDEX + 1;
+
+    public static final int ID_INDEX = MODE_INDEX + 1;
+
+    private static final int PARAMS_INDEX = ID_INDEX + 1;
+
+    public static final int NB_GROUPS = ID_INDEX;
+
+    private static final String CONTENT_TYPE = "content";
+
+    private static final String MEDIA_TYPE = "media";
+
+    private static final String IMAGE_TYPE = "image";
+
+    private static final String DOWNLOAD_MODE = "download";
+
+    private static final String INLINE_MODE = "inline";
+
+    /*
+     * Parameters Keys
+     */
+
+    private static final String KEEP_SIZE_PARAM = "keepSize";
+
+    private static final String SCALE_PARAM = "scale";
+
+    private static final String STYLE_PARAM = "style";
+
+    /*
+     * Default Values
+     */
+
+    private static final String IMAGE_SCALE = "width(768)";
+
+    private static final int DEFAULT_WIDTH = 768;
+
+    private static final String IMAGE_NO_SCALING = "full";
+
+    public static final Pattern CONTENT_PATTERN = Pattern.compile(
+        "(?:href|src)=(\"((" + CONTENT_TYPE + "|" + MEDIA_TYPE + "|" + IMAGE_TYPE + ")://(?:(" + DOWNLOAD_MODE + "|" + INLINE_MODE +
+            ")/)?([0-9a-z-/]+)(\\?[^\"]+)?)\")", Pattern.MULTILINE | Pattern.UNIX_LINES );
+
+    private static final Pattern ASPECT_RATIO_PATTEN = Pattern.compile( "^(?<horizontalProportion>\\d+):(?<verticalProportion>\\d+)$" );
+
+    private final ContentService contentService;
+
+    private final StyleDescriptorService styleDescriptorService;
+
+    private final PortalUrlService portalUrlService;
+
+    public HtmlLinkProcessor( final ContentService contentService, final StyleDescriptorService styleDescriptorService,
+                              final PortalUrlService portalUrlService )
+    {
+        this.contentService = contentService;
+        this.styleDescriptorService = styleDescriptorService;
+        this.portalUrlService = portalUrlService;
+    }
+
+    public String process( final String text, final String urlType, final PortalRequest portalRequest )
+    {
+        String processedHtml = text;
+        final ImmutableMap<String, ImageStyle> imageStyleMap = getImageStyleMap( portalRequest );
+        final Matcher contentMatcher = CONTENT_PATTERN.matcher( text );
+
+        while ( contentMatcher.find() )
+        {
+            if ( contentMatcher.groupCount() >= NB_GROUPS )
+            {
+                final String match = contentMatcher.group( MATCH_INDEX );
+                final String link = contentMatcher.group( LINK_INDEX );
+                final String type = contentMatcher.group( TYPE_INDEX );
+                final String mode = contentMatcher.group( MODE_INDEX );
+                final String id = contentMatcher.group( ID_INDEX );
+                final String urlParamsString = contentMatcher.groupCount() == PARAMS_INDEX ? contentMatcher.group( PARAMS_INDEX ) : null;
+
+                switch ( type )
+                {
+                    case CONTENT_TYPE:
+                        PageUrlParams pageUrlParams = new PageUrlParams().
+                            type( urlType ).
+                            id( id ).
+                            portalRequest( portalRequest );
+                        final String pageUrl = portalUrlService.pageUrl( pageUrlParams );
+                        processedHtml = processedHtml.replaceFirst( Pattern.quote( match ), "\"" + pageUrl + "\"" );
+                        break;
+                    case IMAGE_TYPE:
+                        final Map<String, String> urlParams = extractUrlParams( urlParamsString );
+
+                        ImageStyle imageStyle = getImageStyle( imageStyleMap, urlParams );
+
+                        ImageUrlParams imageUrlParams = new ImageUrlParams().
+                            type( urlType ).
+                            id( id ).
+                            scale( getScale( id, imageStyle, urlParams ) ).
+                            filter( getFilter( imageStyle ) ).
+                            portalRequest( portalRequest );
+
+                        final String imageUrl = portalUrlService.imageUrl( imageUrlParams );
+
+                        processedHtml = processedHtml.replaceFirst( Pattern.quote( match ), "\"" + imageUrl + "\"" );
+                        break;
+                    default:
+                        AttachmentUrlParams attachmentUrlParams = new AttachmentUrlParams().
+                            type( urlType ).
+                            id( id ).
+                            download( DOWNLOAD_MODE.equals( mode ) ).
+                            portalRequest( portalRequest );
+
+                        final String attachmentUrl = portalUrlService.attachmentUrl( attachmentUrlParams );
+
+                        processedHtml = processedHtml.replaceFirst( Pattern.quote( match ), "\"" + attachmentUrl + "\"" );
+                        break;
+                }
+            }
+        }
+        return processedHtml;
+    }
+
+    private ImmutableMap<String, ImageStyle> getImageStyleMap( final PortalRequest portalRequest )
+    {
+        final ImmutableMap.Builder<String, ImageStyle> imageStyleMap = ImmutableMap.builder();
+        final StyleDescriptors styleDescriptors = getStyleDescriptors( portalRequest );
+        styleDescriptors.stream().
+            flatMap( styleDescriptor -> styleDescriptor.getElements().stream() ).
+            filter( elementStyle -> ImageStyle.STYLE_ELEMENT_NAME.equals( elementStyle.getElement() ) ).
+            forEach( elementStyle -> imageStyleMap.put( elementStyle.getName(), (ImageStyle) elementStyle ) );
+        return imageStyleMap.build();
+    }
+
+    private StyleDescriptors getStyleDescriptors( final PortalRequest portalRequest )
+    {
+        final ImmutableList.Builder<ApplicationKey> applicationKeyList = new ImmutableList.Builder<ApplicationKey>().
+            add( SYSTEM_APPLICATION_KEY );
+        if ( portalRequest != null )
+        {
+            final Site site = portalRequest.getSite();
+            if ( site != null )
+            {
+                final ImmutableSet<ApplicationKey> siteApplicationKeySet = site.getSiteConfigs().getApplicationKeys();
+                applicationKeyList.addAll( siteApplicationKeySet );
+            }
+        }
+
+        final ApplicationKeys applicationKeys = ApplicationKeys.from( applicationKeyList.build() );
+        return styleDescriptorService.getByApplications( applicationKeys );
+    }
+
+    private ImageStyle getImageStyle( final Map<String, ImageStyle> imageStyleMap, final Map<String, String> urlParams )
+    {
+        final String styleString = urlParams.get( STYLE_PARAM );
+        if ( styleString != null )
+        {
+            return imageStyleMap.get( styleString );
+        }
+        return null;
+    }
+
+    private String getScale( final String id, final ImageStyle imageStyle, final Map<String, String> urlParams )
+    {
+        final String aspectRatio = getAspectRation( imageStyle, urlParams );
+        final boolean keepSize = urlParams.containsKey( KEEP_SIZE_PARAM );
+
+        if ( aspectRatio != null )
+        {
+            final Matcher matcher = ASPECT_RATIO_PATTEN.matcher( aspectRatio );
+            if ( !matcher.matches() )
+            {
+                throw new IllegalArgumentException( "Invalid aspect ratio: " + aspectRatio );
+            }
+            final String horizontalProportion = matcher.group( "horizontalProportion" );
+            final String verticalProportion = matcher.group( "verticalProportion" );
+
+            final int width = keepSize ? getImageOriginalWidth( id ) : DEFAULT_WIDTH;
+            final int height = width / Integer.parseInt( horizontalProportion ) * Integer.parseInt( verticalProportion );
+
+            return "block(" + width + "," + height + ")";
+        }
+
+        if ( keepSize)
+        {
+            return IMAGE_NO_SCALING;
+        }
+        return IMAGE_SCALE;
+    }
+
+    private String getFilter( final ImageStyle imageStyle )
+    {
+        return imageStyle == null ? null : imageStyle.getFilter();
+    }
+
+    private String getAspectRation( final ImageStyle imageStyle, final Map<String, String> urlParams )
+    {
+        if ( imageStyle != null )
+        {
+            final String aspectRatio = imageStyle.getAspectRatio();
+            if ( aspectRatio != null )
+            {
+                return aspectRatio;
+            }
+        }
+        return urlParams.get( SCALE_PARAM );
+    }
+
+
+    private int getImageOriginalWidth( final String id )
+    {
+        final Content content = this.getContent( ContentId.from( id ) );
+
+        if ( content instanceof Media )
+        {
+            ExtraData imageData = content.getAllExtraData().getMetadata( MediaInfo.IMAGE_INFO_METADATA_NAME );
+
+            if ( imageData != null )
+            {
+                final Property widthProperty = imageData.getData().getProperty( MediaInfo.IMAGE_INFO_IMAGE_WIDTH );
+                if ( widthProperty != null )
+                {
+                    return widthProperty.getValue().asLong().intValue();
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private Content getContent( final ContentId contentId )
+    {
+        try
+        {
+            return this.contentService.getById( contentId );
+        }
+        catch ( ContentNotFoundException e )
+        {
+            return null;
+        }
+    }
+
+    private Map<String, String> extractUrlParams( final String urlQuery )
+    {
+        if ( urlQuery == null )
+        {
+            return Collections.emptyMap();
+        }
+        final String query = urlQuery.startsWith( "?" ) ? urlQuery.substring( 1 ) : urlQuery;
+        return Splitter.on( '&' ).
+            trimResults().
+            withKeyValueSeparator( "=" ).
+            split( query.replace( "&amp;", "&" ) );
+    }
+
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/HtmlMacroProcessor.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/HtmlMacroProcessor.java
@@ -1,0 +1,33 @@
+package com.enonic.lib.guillotine.macro;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.enonic.xp.macro.MacroService;
+
+public class HtmlMacroProcessor
+{
+    private final MacroService macroService;
+
+    public HtmlMacroProcessor( final MacroService macroService )
+    {
+        this.macroService = macroService;
+    }
+
+    public HtmlAreaProcessedResult process( final String text )
+    {
+        final List<MacroDecorator> processedMacros = new ArrayList<>();
+
+        final String processedHtml = macroService.evaluateMacros( text, ( macro ) -> {
+            final MacroDecorator macroDecorator = MacroDecorator.from( macro );
+
+            processedMacros.add( macroDecorator );
+
+            return new MacroEditorSerializer( macroDecorator ).serialize();
+        } );
+
+        return new HtmlAreaProcessedResult( processedHtml, processedMacros.stream().
+            collect( Collectors.toMap( MacroDecorator::getId, HtmlMacroResult::new ) ) );
+    }
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/HtmlMacroResult.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/HtmlMacroResult.java
@@ -1,0 +1,26 @@
+package com.enonic.lib.guillotine.macro;
+
+import java.util.Map;
+
+public class HtmlMacroResult
+{
+    private final String processedAsHtml;
+
+    private final Map<String, Object> processedAsJson;
+
+    HtmlMacroResult( final MacroDecorator macro )
+    {
+        this.processedAsHtml = new MacroEditorSerializer( macro ).serialize();
+        this.processedAsJson = new MacroEditorJsonSerializer( macro ).serialize();
+    }
+
+    public String getProcessedAsHtml()
+    {
+        return processedAsHtml;
+    }
+
+    public Map<String, Object> getProcessedAsJson()
+    {
+        return processedAsJson;
+    }
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/MacroDecorator.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/MacroDecorator.java
@@ -1,0 +1,33 @@
+package com.enonic.lib.guillotine.macro;
+
+import java.util.UUID;
+
+import com.enonic.xp.macro.Macro;
+
+public class MacroDecorator
+{
+    private final Macro macro;
+
+    private final String id;
+
+    private MacroDecorator( final Macro macro )
+    {
+        this.macro = macro;
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public static MacroDecorator from( final Macro macro )
+    {
+        return new MacroDecorator( macro );
+    }
+
+    public Macro getMacro()
+    {
+        return macro;
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/MacroEditorJsonSerializer.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/MacroEditorJsonSerializer.java
@@ -1,0 +1,44 @@
+package com.enonic.lib.guillotine.macro;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMultimap;
+
+public class MacroEditorJsonSerializer
+{
+    private final MacroDecorator macro;
+
+    public MacroEditorJsonSerializer( final MacroDecorator macro )
+    {
+        this.macro = macro;
+    }
+
+    public Map<String, Object> serialize()
+    {
+        final Map<String, Object> result = new LinkedHashMap<>();
+
+        result.put( "_name", macro.getMacro().getName() );
+        result.put( "_ref", macro.getId() );
+
+        final ImmutableMultimap<String, String> params = macro.getMacro().getParameters();
+
+        for ( String key : params.keySet() )
+        {
+            for ( String value : params.get( key ) )
+            {
+                result.put( key, escapeSpecialChars( value ) );
+            }
+        }
+
+        result.put( "body", macro.getMacro().getBody() );
+
+        return result;
+    }
+
+    private String escapeSpecialChars( final String value )
+    {
+        return value.replaceAll( "\"", "\\\\\"" ).replaceAll( "--", "\\\\-\\\\-" );
+    }
+
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/MacroEditorSerializer.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/MacroEditorSerializer.java
@@ -1,0 +1,59 @@
+package com.enonic.lib.guillotine.macro;
+
+import com.google.common.collect.ImmutableMultimap;
+
+class MacroEditorSerializer
+{
+    private static final String START_TAG = "<editor-macro ";
+
+    private static final String EDITOR_MACRO_END_TAG = "</editor-macro>";
+
+    private final MacroDecorator macro;
+
+    MacroEditorSerializer( final MacroDecorator macro )
+    {
+        this.macro = macro;
+    }
+
+
+    String serialize()
+    {
+        return START_TAG + makeNameAttribute() + " " + makeRefAttribute() + makeParamsAttributes() + ">" + makeBody() +
+            EDITOR_MACRO_END_TAG;
+    }
+
+    private String makeNameAttribute()
+    {
+        return "_name=\"" + macro.getMacro().getName() + "\"";
+    }
+
+    private String makeRefAttribute()
+    {
+        return "_ref=\"" + macro.getId() + "\"";
+    }
+
+    private String makeParamsAttributes()
+    {
+        final StringBuilder result = new StringBuilder();
+        final ImmutableMultimap<String, String> params = macro.getMacro().getParameters();
+        for ( String key : params.keySet() )
+        {
+            for ( String value : params.get( key ) )
+            {
+                String escapedVal = escapeSpecialChars( value );
+                result.append( " " ).append( key ).append( "=\"" ).append( escapedVal ).append( "\"" );
+            }
+        }
+        return result.toString();
+    }
+
+    private String makeBody()
+    {
+        return macro.getMacro().getBody() != null ? escapeSpecialChars( macro.getMacro().getBody() ) : "";
+    }
+
+    private String escapeSpecialChars( final String value )
+    {
+        return value.replaceAll( "\"", "\\\\\"" ).replaceAll( "--", "\\\\-\\\\-" );
+    }
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/ProcessHtmlParams.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/ProcessHtmlParams.java
@@ -1,0 +1,46 @@
+package com.enonic.lib.guillotine.macro;
+
+import com.enonic.xp.portal.PortalRequest;
+import com.enonic.xp.portal.url.UrlTypeConstants;
+
+public class ProcessHtmlParams
+{
+    private String value;
+
+    private PortalRequest portalRequest;
+
+    private String type = UrlTypeConstants.SERVER_RELATIVE;
+
+    public String getValue()
+    {
+        return value;
+    }
+
+    public ProcessHtmlParams setValue( String value )
+    {
+        this.value = value;
+        return this;
+    }
+
+    public ProcessHtmlParams setPortalRequest( PortalRequest portalRequest )
+    {
+        this.portalRequest = portalRequest;
+        return this;
+    }
+
+    public PortalRequest getPortalRequest()
+    {
+        return portalRequest;
+    }
+
+    public ProcessHtmlParams setType( String type )
+    {
+        this.type = type;
+        return this;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/ProcessHtmlService.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/ProcessHtmlService.java
@@ -1,0 +1,6 @@
+package com.enonic.lib.guillotine.macro;
+
+public interface ProcessHtmlService
+{
+    HtmlAreaProcessedResult processHtml( final ProcessHtmlParams params );
+}

--- a/src/main/java/com/enonic/lib/guillotine/macro/ProcessHtmlServiceImpl.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/ProcessHtmlServiceImpl.java
@@ -1,0 +1,46 @@
+package com.enonic.lib.guillotine.macro;
+
+import com.enonic.xp.content.ContentService;
+import com.enonic.xp.macro.MacroService;
+import com.enonic.xp.portal.url.PortalUrlService;
+import com.enonic.xp.style.StyleDescriptorService;
+
+public class ProcessHtmlServiceImpl
+    implements ProcessHtmlService
+{
+    private final ContentService contentService;
+
+    private final StyleDescriptorService styleDescriptorService;
+
+    private final PortalUrlService portalUrlService;
+
+    private final MacroService macroService;
+
+    public ProcessHtmlServiceImpl( final ContentService contentService, final StyleDescriptorService styleDescriptorService,
+                                   final PortalUrlService portalUrlService, final MacroService macroService )
+    {
+        this.contentService = contentService;
+        this.styleDescriptorService = styleDescriptorService;
+        this.portalUrlService = portalUrlService;
+        this.macroService = macroService;
+    }
+
+    @Override
+    public HtmlAreaProcessedResult processHtml( final ProcessHtmlParams params )
+    {
+        if ( params.getValue() == null || params.getValue().isEmpty() )
+        {
+            return HtmlAreaProcessedResult.empty();
+        }
+
+        String processedHtml = new HtmlLinkProcessor( contentService, styleDescriptorService, portalUrlService ).
+            process( unescapeValue( params.getValue() ), params.getType(), params.getPortalRequest() );
+
+        return new HtmlMacroProcessor( macroService ).process( processedHtml );
+    }
+
+    private String unescapeValue( String value )
+    {
+        return value.replace( "\\", "" );
+    }
+}

--- a/src/main/java/com/enonic/lib/guillotine/mapper/HtmlAreaResultMapper.java
+++ b/src/main/java/com/enonic/lib/guillotine/mapper/HtmlAreaResultMapper.java
@@ -1,0 +1,37 @@
+package com.enonic.lib.guillotine.mapper;
+
+import com.enonic.lib.guillotine.macro.HtmlAreaProcessedResult;
+import com.enonic.xp.script.serializer.MapGenerator;
+import com.enonic.xp.script.serializer.MapSerializable;
+
+public class HtmlAreaResultMapper
+    implements MapSerializable
+{
+
+    private final HtmlAreaProcessedResult htmlAreaResult;
+
+    public HtmlAreaResultMapper( final HtmlAreaProcessedResult htmlMacrosResult )
+    {
+        this.htmlAreaResult = htmlMacrosResult;
+    }
+
+    @Override
+    public void serialize( final MapGenerator gen )
+    {
+        gen.value( "value", htmlAreaResult.getProcessedHtml() );
+
+        if ( htmlAreaResult.getMacrosAsMap() != null )
+        {
+            gen.map( "macros" );
+
+            htmlAreaResult.getMacrosAsMap().forEach( ( key, value ) -> {
+                gen.map( key );
+                gen.value( "macroAsHtml", value.getProcessedAsHtml() );
+                gen.value( "macroAsJson", value.getProcessedAsJson() );
+                gen.end();
+            } );
+
+            gen.end();
+        }
+    }
+}

--- a/src/main/resources/lib/guillotine/dynamic/form.js
+++ b/src/main/resources/lib/guillotine/dynamic/form.js
@@ -5,6 +5,7 @@ const namingLib = require('/lib/guillotine/util/naming');
 const utilLib = require('/lib/guillotine/util/util');
 const graphQlLib = require('/lib/guillotine/graphql');
 const validationLib = require('/lib/guillotine/util/validation');
+const macroLib = require('/lib/guillotine/macro');
 
 function getFormItems(form) {
     var formItems = [];
@@ -99,7 +100,7 @@ function generateInputObjectType(context, input) {
     case 'GeoPoint':
         return context.types.geoPointType;
     case 'HtmlArea':
-        return graphQlLib.GraphQLString;
+        return context.types.htmlAreaResultType;
     case 'ImageSelector':
         return graphQlLib.reference('Content');
     case 'ImageUploader':
@@ -202,7 +203,10 @@ function generateFormItemResolveFunction(formItem) {
             let value = env.source[formItem.name];
 
             if (value && env.args.processHtml) {
-                value = portalLib.processHtml({value: value, type: env.args.processHtml.type});
+                value = macroLib.processHtml({
+                    value: value,
+                    type: env.args.processHtml.type
+                })
             }
             if (value && 'Input' === formItem.formItemType) {
                 if ('AttachmentUploader' === formItem.inputType) {
@@ -235,7 +239,10 @@ function generateFormItemResolveFunction(formItem) {
             }
             if (env.args.processHtml) {
                 values = values.map(function (value) {
-                    return portalLib.processHtml({value: value, type: env.args.processHtml.type});
+                    return macroLib.processHtml({
+                        value: value,
+                        type: env.args.processHtml.type
+                    });
                 });
             }
             if ('Input' === formItem.formItemType) {

--- a/src/main/resources/lib/guillotine/generic/generic-content-types.js
+++ b/src/main/resources/lib/guillotine/generic/generic-content-types.js
@@ -67,6 +67,25 @@ function generateTypes(context) {
             }
         }
     });
+
+    context.types.htmlAreaResultType = graphQlLib.createObjectType(context, {
+        name: context.uniqueName('HtmlAreaResult'),
+        description: 'HtmlAreaResult type.',
+        fields: {
+            value: {
+                type: graphQlLib.GraphQLString,
+                resolve: function (env) {
+                    return env.source.value;
+                }
+            },
+            macros: {
+                type: graphQlLib.Json,
+                resolve: function (env) {
+                    return env.source.macros;
+                }
+            }
+        }
+    });
 };
 
 exports.generateTypes = generateTypes;

--- a/src/main/resources/lib/guillotine/macro.js
+++ b/src/main/resources/lib/guillotine/macro.js
@@ -1,0 +1,6 @@
+/* global __ */
+
+exports.processHtml = function (params) {
+    let bean = __.newBean('com.enonic.lib.guillotine.ProcessHtmlHandler');
+    return bean.processHtml(__.toScriptValue(params));
+};

--- a/src/main/resources/lib/guillotine/query/content-api.js
+++ b/src/main/resources/lib/guillotine/query/content-api.js
@@ -239,7 +239,7 @@ function getContent(env, context) {
 }
 
 function transformNodeIfExistsAttachments(node) {
-    if (node.hasOwnProperty('attachments') && Object.keys(node.attachments).length > 0) {
+    if (node && node.hasOwnProperty('attachments') && Object.keys(node.attachments).length > 0) {
         if (node.data) {
             node.data['__nodeId'] = node._id;
             addRecursiveNodeId(node.data, node._id);


### PR DESCRIPTION
Returns processed value of HtmlArea as an Object instead of String:
```
 {
  "value": "<p><editor-macro _name=\"testmacro\" _ref=\"2726f0a7-50f9-47bc-9bd0-f3e6d6d6d257\" defaultText=\"Hello World!\"></editor-macro></p>\n",
  "macros": {
    "2726f0a7-50f9-47bc-9bd0-f3e6d6d6d257": {
      "macroAsHtml": "<editor-macro _name=\"testmacro\" _ref=\"2726f0a7-50f9-47bc-9bd0-f3e6d6d6d257\" defaultText=\"Hello World!\"></editor-macro>",
      "macroAsJson": {
        "_name": "testmacro",
        "_ref": "2726f0a7-50f9-47bc-9bd0-f3e6d6d6d257",
        "defaultText": "Hello World!",
        "body": ""
      }
    }
  }
}
```