### PR TITLE
Flatten macros structure v2 #109

### DIFF
--- a/src/main/java/com/enonic/lib/guillotine/handler/ComponentDescriptorHandler.java
+++ b/src/main/java/com/enonic/lib/guillotine/handler/ComponentDescriptorHandler.java
@@ -1,11 +1,14 @@
 package com.enonic.lib.guillotine.handler;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.enonic.lib.guillotine.mapper.ComponentDescriptorMapper;
 import com.enonic.lib.guillotine.mapper.MacroDescriptorMapper;
 import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.app.ApplicationKeys;
 import com.enonic.xp.macro.MacroDescriptorService;
 import com.enonic.xp.page.PageDescriptorService;
 import com.enonic.xp.region.LayoutDescriptorService;
@@ -33,7 +36,7 @@ public class ComponentDescriptorHandler
         this.macroDescriptorServiceSupplier = context.getService( MacroDescriptorService.class );
     }
 
-    public Object getByApplication( final String componentType, final String applicationKey )
+    public Object getComponentDescriptors( final String componentType, final String applicationKey )
     {
         final ApplicationKey appKey = ApplicationKey.from( applicationKey );
 
@@ -54,13 +57,23 @@ public class ComponentDescriptorHandler
                     stream().
                     map( ComponentDescriptorMapper::new ).
                     collect( Collectors.toList() );
-            case "Macro":
-                return macroDescriptorServiceSupplier.get().getByApplication( appKey ).
-                    stream().
-                    map( MacroDescriptorMapper::new ).
-                    collect( Collectors.toList() );
             default:
                 throw new IllegalArgumentException( "Unsupported component type \"" + componentType + "\"" );
         }
+    }
+
+    public List<MacroDescriptorMapper> getMacroDescriptors( final List<String> applicationKeys )
+    {
+        // assumption that given applicationKeys have the same order if them was given from site configs
+        // It means that first macro descriptor which was matched will be used to process it
+        final List<ApplicationKey> appKeys =
+            new ArrayList<>( applicationKeys.stream().map( ApplicationKey::from ).collect( Collectors.toList() ) );
+
+        appKeys.add( ApplicationKey.SYSTEM );
+
+        return macroDescriptorServiceSupplier.get().getByApplications( ApplicationKeys.from( appKeys ) ).
+            stream().
+            map( MacroDescriptorMapper::new ).
+            collect( Collectors.toList() );
     }
 }

--- a/src/main/java/com/enonic/lib/guillotine/macro/HtmlAreaProcessedResult.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/HtmlAreaProcessedResult.java
@@ -9,7 +9,7 @@ public class HtmlAreaProcessedResult
 
     private final List<HtmlMacroResult> macrosAsJson;
 
-    private Map<String, Map<String, List<Map<String, Object>>>> macros;
+    private List<Map<String, Object>> macros;
 
     public HtmlAreaProcessedResult( final String processedHtml, final List<HtmlMacroResult> macroMap )
     {
@@ -17,7 +17,7 @@ public class HtmlAreaProcessedResult
         this.macrosAsJson = macroMap;
     }
 
-    public void setMacros( final Map<String, Map<String, List<Map<String, Object>>>> macros )
+    public void setMacros( final List<Map<String, Object>> macros )
     {
         this.macros = macros;
     }
@@ -32,7 +32,7 @@ public class HtmlAreaProcessedResult
         return macrosAsJson;
     }
 
-    public Map<String, Map<String, List<Map<String, Object>>>> getMacros()
+    public List<Map<String, Object>> getMacros()
     {
         return macros;
     }

--- a/src/main/java/com/enonic/lib/guillotine/macro/HtmlMacroProcessor.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/HtmlMacroProcessor.java
@@ -10,9 +10,12 @@ public class HtmlMacroProcessor
 {
     private final MacroService macroService;
 
-    public HtmlMacroProcessor( final MacroService macroService )
+    private final List<String> registeredMacroNames;
+
+    public HtmlMacroProcessor( final MacroService macroService, final List<String> registeredMacroNames )
     {
         this.macroService = macroService;
+        this.registeredMacroNames = registeredMacroNames;
     }
 
     public HtmlAreaProcessedResult process( final String text )
@@ -20,6 +23,11 @@ public class HtmlMacroProcessor
         final List<MacroDecorator> processedMacros = new ArrayList<>();
 
         final String processedHtml = macroService.evaluateMacros( text, ( macro ) -> {
+            if ( !registeredMacroNames.contains( macro.getName() ) )
+            {
+                return macro.toString();
+            }
+
             final MacroDecorator macroDecorator = MacroDecorator.from( macro );
 
             processedMacros.add( macroDecorator );

--- a/src/main/java/com/enonic/lib/guillotine/macro/ProcessHtmlServiceImpl.java
+++ b/src/main/java/com/enonic/lib/guillotine/macro/ProcessHtmlServiceImpl.java
@@ -1,23 +1,20 @@
 package com.enonic.lib.guillotine.macro;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.stream.Collectors;
 
 import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.app.ApplicationKeys;
 import com.enonic.xp.content.ContentService;
 import com.enonic.xp.macro.MacroDescriptor;
 import com.enonic.xp.macro.MacroDescriptorService;
-import com.enonic.xp.macro.MacroDescriptors;
-import com.enonic.xp.macro.MacroKey;
 import com.enonic.xp.macro.MacroService;
 import com.enonic.xp.portal.url.PortalUrlService;
 import com.enonic.xp.site.Site;
 import com.enonic.xp.site.SiteConfig;
-import com.enonic.xp.site.SiteConfigs;
 import com.enonic.xp.style.StyleDescriptorService;
 
 public class ProcessHtmlServiceImpl
@@ -55,99 +52,45 @@ public class ProcessHtmlServiceImpl
         String processedHtml = new HtmlLinkProcessor( contentService, styleDescriptorService, portalUrlService ).
             process( unescapeValue( params.getValue() ), params.getType(), params.getPortalRequest() );
 
-        final HtmlAreaProcessedResult result = new HtmlMacroProcessor( macroService ).process( processedHtml );
+        final List<String> registeredMacroNames = getRegisteredMacrosInSystemForSite( params.getPortalRequest().getSite() );
 
-        buildMacros( result, params.getPortalRequest().getSite() );
+        final HtmlAreaProcessedResult result = new HtmlMacroProcessor( macroService, registeredMacroNames ).process( processedHtml );
+
+        buildMacros( result );
 
         return result;
     }
 
-    private void buildMacros( final HtmlAreaProcessedResult result, final Site site )
+    private void buildMacros( final HtmlAreaProcessedResult result )
     {
         if ( result.getMacrosAsJson() == null || result.getMacrosAsJson().isEmpty() )
         {
             return;
         }
 
-        final Map<String, List<Map<String, Object>>> macrosGroupedByName = new HashMap<>();
+        final List<Map<String, Object>> macros = new ArrayList<>();
 
         result.getMacrosAsJson().forEach( macro -> {
             final Object macroName = macro.getProcessedAsJson().get( "macroName" );
 
-            if ( !macrosGroupedByName.containsKey( macroName.toString() ) )
-            {
-                macrosGroupedByName.put( macroName.toString(), new ArrayList<>() );
-            }
-
-            macrosGroupedByName.get( macroName.toString() ).add( macro.getProcessedAsJson() );
-        } );
-
-        final Map<String, Map<String, List<Map<String, Object>>>> macros = new LinkedHashMap<>();
-
-        macrosGroupedByName.keySet().forEach( macroName -> {
-            MacroDescriptor macroDescriptor = resolveMacroDescriptor( site, macroName );
-
-            if ( macroDescriptor != null )
-            {
-                final String applicationKey = macroDescriptor.getKey().getApplicationKey().toString();
-                if ( !macros.containsKey( applicationKey ) )
-                {
-                    macros.put( applicationKey, new LinkedHashMap<>() );
-                }
-                if ( !macros.get( applicationKey ).containsKey( macroName ) )
-                {
-                    macros.get( applicationKey ).put( macroName, new ArrayList<>() );
-                }
-                macros.get( applicationKey ).get( macroName ).addAll( macrosGroupedByName.get( macroName ) );
-            }
+            macros.add( Collections.singletonMap( macroName.toString(), macro.getProcessedAsJson() ) );
         } );
 
         result.setMacros( macros );
     }
 
-    private MacroDescriptor resolveMacroDescriptor( final Site site, final String macroName )
+    private List<String> getRegisteredMacrosInSystemForSite( final Site site )
     {
-        //Searches for the macro in the applications associated to the site
-        final SiteConfigs siteConfigs = site.getSiteConfigs();
-        MacroDescriptor macroDescriptor = siteConfigs.
+        final List<ApplicationKey> applicationKeys = site.getSiteConfigs().stream().
+            map( SiteConfig::getApplicationKey ).collect( Collectors.toList() );
+
+        applicationKeys.add( ApplicationKey.SYSTEM );
+
+        return macroDescriptorService.getByApplications( ApplicationKeys.from( applicationKeys ) ).
             stream().
-            map( siteConfig -> MacroKey.from( siteConfig.getApplicationKey(), macroName ) ).
-            map( macroDescriptorService::getByKey ).
-            filter( Objects::nonNull ).findFirst().
-            orElse( null );
-
-        if ( macroDescriptor == null )
-        {
-            macroDescriptor = resolveMacroDescriptorCaseInsensitive( siteConfigs, macroName );
-        }
-
-        //If there is no corresponding macro
-        if ( macroDescriptor == null )
-        {
-            //Searches in the builtin macros
-            final MacroKey macroKey = MacroKey.from( ApplicationKey.SYSTEM, macroName );
-            macroDescriptor = macroDescriptorService.getByKey( macroKey );
-        }
-
-        return macroDescriptor;
+            map( MacroDescriptor::getName ).collect( Collectors.toList() );
     }
 
-    private MacroDescriptor resolveMacroDescriptorCaseInsensitive( final SiteConfigs siteConfigs, final String macroName )
-    {
-        for ( SiteConfig siteConfig : siteConfigs )
-        {
-            final MacroDescriptors macroDescriptors = macroDescriptorService.getByApplication( siteConfig.getApplicationKey() );
-            final MacroDescriptor macroDescriptor = macroDescriptors.stream().
-                filter( ( md ) -> md.getName().equalsIgnoreCase( macroName ) ).
-                findFirst().
-                orElse( null );
-            if ( macroDescriptor != null )
-            {
-                return macroDescriptor;
-            }
-        }
-        return null;
-    }
 
     private String unescapeValue( String value )
     {

--- a/src/main/java/com/enonic/lib/guillotine/mapper/HtmlAreaResultMapper.java
+++ b/src/main/java/com/enonic/lib/guillotine/mapper/HtmlAreaResultMapper.java
@@ -28,7 +28,7 @@ public class HtmlAreaResultMapper
             }
             gen.end();
 
-            gen.map( "macros" );
+            gen.array( "macros" );
             if ( htmlAreaResult.getMacros() != null )
             {
                 htmlAreaResult.getMacros().forEach( gen::value );

--- a/src/main/resources/lib/guillotine/dynamic/macro-types.js
+++ b/src/main/resources/lib/guillotine/dynamic/macro-types.js
@@ -1,0 +1,67 @@
+/** global __ */
+
+const libs = {
+    graphQL: require('/lib/guillotine/graphql'),
+    naming: require('/lib/guillotine/util/naming'),
+    form: require('/lib/guillotine/dynamic/form')
+};
+
+function getMacroDescriptors(applicationsKeys) {
+    const descriptorBean = __.newBean('com.enonic.lib.guillotine.handler.ComponentDescriptorHandler');
+    return __.toNativeObject(descriptorBean.getMacroDescriptors(applicationsKeys));
+}
+
+function createMacroDataConfigType(context) {
+    let macroDescriptors = getMacroDescriptors(context.options.applications);
+
+    let macroConfigTypeFields = {};
+
+    macroDescriptors.forEach(descriptor => {
+        let sanitizeDescriptorName = libs.naming.sanitizeText(descriptor.name);
+
+        let descriptorTypeName = `Macro_${libs.naming.sanitizeText(descriptor.applicationKey)}_${sanitizeDescriptorName}`;
+
+        let macroDescriptorFields = {
+            macroRef: {
+                type: libs.graphQL.GraphQLString,
+                resolve: function (env) {
+                    return env.source.macroRef;
+                }
+            }
+        };
+
+        libs.form.getFormItems(descriptor.form).forEach(function (formItem) {
+            macroDescriptorFields[libs.naming.sanitizeText(formItem.name)] = {
+                type: libs.form.generateFormItemObjectType(context, descriptorTypeName, formItem),
+                args: libs.form.generateFormItemArguments(context, formItem),
+                resolve: libs.form.generateFormItemResolveFunction(formItem)
+            }
+        });
+
+        const descriptorConfigType = libs.graphQL.createObjectType(context, {
+            name: descriptorTypeName,
+            description: `Macro descriptor config for application ['${descriptor.applicationKey}'] and descriptor ['${descriptor.name}']`,
+            fields: macroDescriptorFields
+        });
+
+        // assumption that macro descriptors have the same order if them was given from site configs
+        // It means that first macro descriptor which was matched will be used to process it
+        if (!macroDescriptorFields.hasOwnProperty(sanitizeDescriptorName)) {
+            macroConfigTypeFields[sanitizeDescriptorName] = {
+                type: descriptorConfigType,
+                resolve: (env) => env.source[descriptor.name]
+            }
+        }
+    });
+
+    if (Object.keys(macroConfigTypeFields).length > 0) {
+        context.types['MacroDataConfigType'] = libs.graphQL.createObjectType(context, {
+            name: context.uniqueName('MacroDataConfig'),
+            description: 'Macro component config.',
+            fields: macroConfigTypeFields
+        });
+    }
+}
+
+
+exports.createMacroDataConfigType = createMacroDataConfigType;

--- a/src/main/resources/lib/guillotine/generic/page-types.js
+++ b/src/main/resources/lib/guillotine/generic/page-types.js
@@ -4,11 +4,13 @@ const nodeLib = require('/lib/xp/node');
 const portalLib = require('/lib/xp/portal');
 
 const graphQlLib = require('/lib/guillotine/graphql');
-const descriptorTypesLib = require('/lib/guillotine/dynamic/descriptor-types');
+const componentTypesLib = require('/lib/guillotine/dynamic/component-types');
 const utilLib = require('/lib/guillotine/util/util');
+const macroTypesLib = require('/lib/guillotine/dynamic/macro-types');
 
 function generateTypes(context) {
-    descriptorTypesLib.createDynamicDataConfigType(context);
+    componentTypesLib.createComponentDataConfigType(context);
+    macroTypesLib.createMacroDataConfigType(context);
 
     context.types.htmlAreaResultType = graphQlLib.createObjectType(context, {
         name: context.uniqueName('HtmlAreaResult'),
@@ -27,7 +29,7 @@ function generateTypes(context) {
                 }
             },
             macros: context.types.MacroDataConfigType && {
-                type: context.types.MacroDataConfigType,
+                type: graphQlLib.list(context.types.MacroDataConfigType),
                 resolve: function (env) {
                     return env.source.macros;
                 }

--- a/src/test/java/com/enonic/lib/guillotine/handler/ComponentDescriptorHandlerTest.java
+++ b/src/test/java/com/enonic/lib/guillotine/handler/ComponentDescriptorHandlerTest.java
@@ -1,5 +1,6 @@
 package com.enonic.lib.guillotine.handler;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.enonic.lib.guillotine.mapper.ComponentDescriptorMapper;
 import com.enonic.lib.guillotine.mapper.MacroDescriptorMapper;
 import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.app.ApplicationKeys;
 import com.enonic.xp.form.Form;
 import com.enonic.xp.form.Input;
 import com.enonic.xp.inputtype.InputTypeName;
@@ -88,7 +90,7 @@ public class ComponentDescriptorHandlerTest
 
         when( pageDescriptorService.getByApplication( any( ApplicationKey.class ) ) ).thenReturn( pageDescriptors );
 
-        final Object result = instance.getByApplication( "Page", "app-guillotine" );
+        final Object result = instance.getComponentDescriptors( "Page", "app-guillotine" );
 
         assertNotNull( result );
 
@@ -120,7 +122,7 @@ public class ComponentDescriptorHandlerTest
 
         when( partDescriptorService.getByApplication( any( ApplicationKey.class ) ) ).thenReturn( descriptors );
 
-        final Object result = instance.getByApplication( "Part", "app-guillotine" );
+        final Object result = instance.getComponentDescriptors( "Part", "app-guillotine" );
 
         assertNotNull( result );
 
@@ -153,7 +155,7 @@ public class ComponentDescriptorHandlerTest
 
         when( layoutDescriptorService.getByApplication( any( ApplicationKey.class ) ) ).thenReturn( descriptors );
 
-        final Object result = instance.getByApplication( "Layout", "app-guillotine" );
+        final Object result = instance.getComponentDescriptors( "Layout", "app-guillotine" );
 
         assertNotNull( result );
 
@@ -172,7 +174,7 @@ public class ComponentDescriptorHandlerTest
     }
 
     @Test
-    void testGetByApplicationForMacro()
+    void testGetMacroDescriptors()
     {
         final MacroDescriptors descriptors = MacroDescriptors.from( MacroDescriptor.create().
             displayName( "testMacro" ).
@@ -189,9 +191,9 @@ public class ComponentDescriptorHandlerTest
         final ComponentDescriptorHandler instance = new ComponentDescriptorHandler();
         instance.initialize( newBeanContext( ResourceKey.from( "com.app:/test" ) ) );
 
-        when( macroDescriptorService.getByApplication( any( ApplicationKey.class ) ) ).thenReturn( descriptors );
+        when( macroDescriptorService.getByApplications( any( ApplicationKeys.class ) ) ).thenReturn( descriptors );
 
-        final Object result = instance.getByApplication( "Macro", "com.app" );
+        final Object result = instance.getMacroDescriptors( Collections.singletonList( "com.app" ) );
 
         assertNotNull( result );
 
@@ -216,7 +218,7 @@ public class ComponentDescriptorHandlerTest
         instance.initialize( newBeanContext( ResourceKey.from( "com.app:/test" ) ) );
 
         final IllegalArgumentException ex =
-            assertThrows( IllegalArgumentException.class, () -> instance.getByApplication( "Unknown", "com.app.name" ) );
+            assertThrows( IllegalArgumentException.class, () -> instance.getComponentDescriptors( "Unknown", "com.app.name" ) );
 
         assertEquals( "Unsupported component type \"Unknown\"", ex.getMessage() );
     }

--- a/src/test/java/com/enonic/lib/guillotine/handler/ProcessHtmlHandlerTest.java
+++ b/src/test/java/com/enonic/lib/guillotine/handler/ProcessHtmlHandlerTest.java
@@ -14,6 +14,7 @@ import com.enonic.xp.form.Input;
 import com.enonic.xp.inputtype.InputTypeName;
 import com.enonic.xp.macro.MacroDescriptor;
 import com.enonic.xp.macro.MacroDescriptorService;
+import com.enonic.xp.macro.MacroDescriptors;
 import com.enonic.xp.macro.MacroKey;
 import com.enonic.xp.macro.MacroService;
 import com.enonic.xp.portal.url.PortalUrlService;
@@ -79,7 +80,8 @@ class ProcessHtmlHandlerTest
             build();
 
         when( styleDescriptorService.getByApplications( any( ApplicationKeys.class ) ) ).thenReturn( StyleDescriptors.empty() );
-        when( macroDescriptorService.getByKey( any( MacroKey.class ) ) ).thenReturn( macroDescriptor );
+        when( macroDescriptorService.getByApplications( any( ApplicationKeys.class ) ) ).thenReturn(
+            MacroDescriptors.from( macroDescriptor ) );
 
         runFunction( "lib/macro-test.js", "testProcessHtml" );
     }

--- a/src/test/resources/lib/macro-test.js
+++ b/src/test/resources/lib/macro-test.js
@@ -17,14 +17,13 @@ exports.testProcessHtml = function () {
     testingLib.assertEquals('Value 12', result.macrosAsJson[0]['field_name_1'][1]);
     testingLib.assertEquals('', result.macrosAsJson[0].body);
     testingLib.assertNotNull(result.macros);
-    testingLib.assertNotNull(result.macros['myapp']);
-    testingLib.assertTrue(result.macros['myapp']['mymacro'].length === 1);
-    testingLib.assertNotNull(result.macros['myapp']['mymacro'][0]);
+    testingLib.assertTrue(result.macros.length === 1);
+    testingLib.assertNotNull(result.macros[0]['mymacro']);
 
-    testingLib.assertEquals("mymacro", result.macros['myapp']['mymacro'][0].macroName);
-    testingLib.assertNotNull(result.macros['myapp']['mymacro'][0].macroRef);
-    testingLib.assertNotNull(result.macros['myapp']['mymacro'][0]['field_name_1']);
-    testingLib.assertEquals('Value 11', result.macros['myapp']['mymacro'][0]['field_name_1'][0]);
-    testingLib.assertEquals('Value 12', result.macros['myapp']['mymacro'][0]['field_name_1'][1]);
-    testingLib.assertEquals('', result.macros['myapp']['mymacro'][0].body);
+    testingLib.assertEquals("mymacro", result.macros[0]['mymacro'].macroName);
+    testingLib.assertNotNull(result.macros[0]['mymacro'].macroRef);
+    testingLib.assertNotNull(result.macros[0]['mymacro']['field_name_1']);
+    testingLib.assertEquals('Value 11', result.macros[0]['mymacro']['field_name_1'][0]);
+    testingLib.assertEquals('Value 12', result.macros[0]['mymacro']['field_name_1'][1]);
+    testingLib.assertEquals('', result.macros[0]['mymacro'].body);
 };


### PR DESCRIPTION
This is possible with the assumption that applications provided for schema generation are same to applications in Site.

If macro does not have a descriptor then it will not be processed. 
Type `MacroDataConfigType` does not contain macros without descriptor.