### PR TITLE
`boost` param cannot be used in `boolean` query #285

### DIFF
--- a/src/main/resources/lib/guillotine/util/factory.js
+++ b/src/main/resources/lib/guillotine/util/factory.js
@@ -262,17 +262,18 @@ function createDslBooleanExpression(holder, expression) {
         if (expression.should) {
             dslExpression.should = [];
             (expression.should || []).forEach(boolExpression => dslExpression.should.push(createDslQuery(boolExpression)))
-        } else if (expression.must) {
+        }
+        if (expression.must) {
             dslExpression.must = [];
             (expression.must || []).forEach(boolExpression => dslExpression.must.push(createDslQuery(boolExpression)))
-        } else if (expression.mustNot) {
+        }
+        if (expression.mustNot) {
             dslExpression.mustNot = [];
             (expression.mustNot || []).forEach(boolExpression => dslExpression.mustNot.push(createDslQuery(boolExpression)))
-        } else if (expression.filter) {
+        }
+        if (expression.filter) {
             dslExpression.filter = [];
             (expression.filter || []).forEach(boolExpression => dslExpression.filter.push(createDslQuery(boolExpression)))
-        } else {
-            throw 'Must be set property for boolean expression';
         }
         holder.boolean = dslExpression;
     }

--- a/src/main/resources/lib/guillotine/util/validation.js
+++ b/src/main/resources/lib/guillotine/util/validation.js
@@ -84,7 +84,6 @@ function validateGraphQlDSLFields(dslQueryObject) {
 function validateGraphQlDslBooleanExpression(dslQueryObject) {
     if (dslQueryObject['boolean'] != null) {
         const booleanField = dslQueryObject['boolean'];
-        validateOnlyOneFieldMustBeNotNull(booleanField, 'Boolean');
         Object.keys(booleanField).filter(fieldName => fieldName !== 'boost').forEach(fieldName => {
             if (booleanField[fieldName] != null) {
                 booleanField[fieldName].forEach(dslQuery => validateGraphQlDSLFields(dslQuery));


### PR DESCRIPTION
- Fixed validation for `BooleanDSLExpression`
- The limitation of setting only one field from `should`, `must`, `mustNot`, or `filter` has been removed. Now it is implemented in the same way as in QueryDSL in XP.